### PR TITLE
serialisation in zcash format

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -27,6 +27,7 @@ criterion = { version = "0.3.6", optional = true } # Dev dep for bench
 ark-bls12-381 = "0.3.0"
 ark-ec = { version = "0.3.0", features = ["parallel"] }
 ark-ff = { version = "0.3.0", features = ["parallel", "asm"] }
+ark-serialize = { version = "0.3" }
 hex = "0.4.3"
 once_cell = "1.8"
 rand = "0.8.5"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -14,6 +14,7 @@ license-file = "../mit-license.md"
 [features]
 default = [ ]
 bench = [ "criterion" ]
+schema-validation = [ ]
 
 [[bench]]
 name = "criterion"
@@ -27,6 +28,7 @@ ark-bls12-381 = "0.3.0"
 ark-ec = { version = "0.3.0", features = ["parallel"] }
 ark-ff = { version = "0.3.0", features = ["parallel", "asm"] }
 hex = "0.4.3"
+once_cell = "1.8"
 rand = "0.8.5"
 rayon = "1.5.3"
 ruint = { version = "1.3.0", features = ["ark-ff"] }
@@ -34,6 +36,7 @@ serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
 thiserror = "1.0.34"
 tracing = "0.1.36"
+valico = "3.6.1"
 zeroize = "1.5.7"
 
 [dev-dependencies]

--- a/crypto/src/contribution.rs
+++ b/crypto/src/contribution.rs
@@ -1,12 +1,17 @@
-use crate::{crypto::g1_mul_glv, g1_subgroup_check, g2_subgroup_check, parse_g, ParseError};
+use crate::{
+    crypto::g1_mul_glv, g1_subgroup_check, g2_subgroup_check, json_schema::CONTRIBUTION_SCHEMA,
+    parse_g, ParseError,
+};
 use ark_bls12_381::{g1, g2, Bls12_381, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::{msm::VariableBaseMSM, AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{One, PrimeField, UniformRand, Zero};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::{cmp::max, iter};
 use thiserror::Error;
-use tracing::{error, instrument};
+use tracing::{error, info, instrument};
+use valico::json_schema::{self, schema::ScopedSchema};
 use zeroize::Zeroizing;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -52,6 +57,8 @@ pub enum ContributionsError {
     InvalidContribution(usize, #[source] ContributionError),
     #[error("Unexpected number of contributions: expected {0}, got {1}")]
     InvalidContributionCount(usize, usize),
+    #[error("Error validating schema")]
+    InvalidSchema(),
 }
 
 #[derive(Clone, Copy, PartialEq, Debug, Error)]
@@ -82,21 +89,38 @@ impl ContributionsJson {
         }
     }
 
+    #[cfg(feature = "schema-validation")]
     pub fn from_json(json: &str) -> Result<Self, ContributionsError> {
-        // let json = serde_json::from_str(json)?;
-        // let validation = schema.validate(&initial);
-        // if !validation.is_strictly_valid() {
-        //     for error in validation.errors {
-        //         error!("{}", error);
-        //     }
-        //     for missing in validation.missing {
-        //         error!("Missing {}", missing);
-        //     }
-        //     // TODO bail!("Initial contribution is not valid.");
-        // }
-        // info!("Initial contribution is json-schema valid.");
-        // TODO:
-        todo!()
+        let json: Value =
+            serde_json::from_str(json).map_err(|_| ContributionsError::InvalidSchema())?;
+
+        let validation = ScopedSchema::new(
+            &json_schema::Scope::new(),
+            &CONTRIBUTION_SCHEMA.lock().unwrap(),
+        )
+        .validate(&json);
+
+        if !validation.is_strictly_valid() {
+            for error in validation.errors {
+                error!("{}", error);
+            }
+            for missing in validation.missing {
+                error!("Missing {}", missing);
+            }
+            error!("Initial contribution is json-schema invalid.");
+            return Err(ContributionsError::InvalidSchema());
+        }
+        info!("Initial contribution is json-schema valid.");
+
+        serde_json::from_value::<Self>(json).map_err(|e| ContributionsError::InvalidSchema())
+    }
+
+    #[cfg(not(feature = "schema-validation"))]
+    pub fn from_json(json: &str) -> Result<Self, ContributionsError> {
+        let json: Value =
+            serde_json::from_str(json).map_err(|_| ContributionsError::InvalidSchema())?;
+
+        serde_json::from_value::<Self>(json).map_err(|e| ContributionsError::InvalidSchema())
     }
 
     pub fn parse(&self) -> Result<Vec<Contribution>, ContributionsError> {

--- a/crypto/src/json_schema.rs
+++ b/crypto/src/json_schema.rs
@@ -1,7 +1,22 @@
-static CONTRIBUTION_SCHEMA: Lazy<Mutex<Schema>> = Lazy::new(|| {
+use std::sync::{Mutex};
+
+use once_cell::sync::Lazy;
+use valico::json_schema::{
+    keywords,
+    schema::{self, CompilationSettings},
+    Schema,
+};
+
+pub static CONTRIBUTION_SCHEMA: Lazy<Mutex<Schema>> = Lazy::new(|| {
     // Load schema
-    let schema =
-serde_json::from_str(include_str!("../../specs/contributionSchema.json")).
-unwrap();     let schema = valico::schema::compile(schema).unwrap();
-    schema
+    let schema = serde_json::from_str(include_str!("../../specs/contributionSchema.json")).unwrap();
+
+    Mutex::new(
+        schema::compile(
+            schema,
+            None,
+            CompilationSettings::new(&keywords::default(), true),
+        )
+        .unwrap(),
+    )
 });

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -7,7 +7,7 @@ mod crypto;
 mod zcash_format;
 mod json_schema;
 
-pub use contribution::{Contribution, ContributionError, ContributionsError, Transcript};
+pub use contribution::{Contribution, ContributionError, ContributionsError, Transcript, ContributionJson};
 pub use crypto::{g1_subgroup_check, g2_subgroup_check};
 pub use zcash_format::{parse_g, ParseError};
 

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -7,7 +7,7 @@ mod crypto;
 mod zcash_format;
 mod json_schema;
 
-pub use contribution::{Contribution, ContributionError, ContributionsError, Transcript, ContributionJson};
+pub use contribution::{Contribution, ContributionError, ContributionsError, Transcript, ContributionsJson};
 pub use crypto::{g1_subgroup_check, g2_subgroup_check};
 pub use zcash_format::{parse_g, ParseError};
 

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -4,10 +4,13 @@
 
 mod contribution;
 mod crypto;
-mod zcash_format;
 mod json_schema;
+mod zcash_format;
 
-pub use contribution::{Contribution, ContributionError, ContributionsError, Transcript, ContributionsJson};
+pub use contribution::{
+    Contribution, ContributionError, ContributionJson, ContributionsError, ContributionsJson,
+    Transcript,
+};
 pub use crypto::{g1_subgroup_check, g2_subgroup_check};
 pub use zcash_format::{parse_g, ParseError};
 

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -5,6 +5,7 @@
 mod contribution;
 mod crypto;
 mod zcash_format;
+mod json_schema;
 
 pub use contribution::{Contribution, ContributionError, ContributionsError, Transcript};
 pub use crypto::{g1_subgroup_check, g2_subgroup_check};

--- a/crypto/src/zcash_format.rs
+++ b/crypto/src/zcash_format.rs
@@ -6,6 +6,7 @@ use ark_ff::{
     fields::{Field, FpParameters, PrimeField},
     BigInteger, Zero,
 };
+use ark_serialize::CanonicalSerialize;
 use hex::FromHexError;
 use thiserror::Error;
 
@@ -119,6 +120,36 @@ pub fn parse_g<P: SWModelParameters>(hex: &str) -> Result<GroupAffine<P>, ParseE
     }
 
     Ok(point)
+}
+
+pub fn encode_p<P: SWModelParameters>(p: GroupAffine<P>) -> std::string::String {
+    // Create some type aliases for the base extension, field and int types.
+    type Extension<P> = <P as ModelParameters>::BaseField;
+    type Prime<P> = <Extension<P> as Field>::BasePrimeField;
+    type Int<P> = <Prime<P> as PrimeField>::BigInt;
+    let modulus = <Prime<P> as PrimeField>::Params::MODULUS;
+
+    // Compute sizes
+    let extension: usize = Extension::<P>::extension_degree()
+        .try_into()
+        .expect("Extension degree should fit usize.");
+    let element_size = Int::<P>::NUM_LIMBS * 8;
+    let size = extension * element_size;
+    let padding_bits = element_size * 8 - modulus.num_bits() as usize;
+    assert!(
+        padding_bits >= 3,
+        "ZCash encoding spec requires three prefix bits, but there is not enough padding."
+    );
+
+    let mut buffer: Vec<u8> = Vec::with_capacity(size);
+    p.serialize(&mut buffer[..])
+        .expect("point serialization failed");
+    // set the third most significant bit to the same as the first bit (signal)
+    buffer[size - 1] |= (buffer[size - 1] & 0x80) >> 2;
+    // set the most significant bit to 1 (compressed form)
+    buffer[size - 1] |= 0x80;
+
+    format!("0x{}", hex::encode(buffer))
 }
 
 #[cfg(test)]

--- a/crypto/src/zcash_format.rs
+++ b/crypto/src/zcash_format.rs
@@ -141,13 +141,14 @@ pub fn encode_p<P: SWModelParameters>(p: GroupAffine<P>) -> std::string::String 
         "ZCash encoding spec requires three prefix bits, but there is not enough padding."
     );
 
-    let mut buffer: Vec<u8> = Vec::with_capacity(size);
+    let mut buffer = vec![0u8; size];
     p.serialize(&mut buffer[..])
         .expect("point serialization failed");
     // set the third most significant bit to the same as the first bit (signal)
     buffer[size - 1] |= (buffer[size - 1] & 0x80) >> 2;
     // set the most significant bit to 1 (compressed form)
     buffer[size - 1] |= 0x80;
+    buffer.reverse();
 
     format!("0x{}", hex::encode(buffer))
 }

--- a/crypto/src/zcash_format.rs
+++ b/crypto/src/zcash_format.rs
@@ -115,9 +115,6 @@ pub fn parse_g<P: SWModelParameters>(hex: &str) -> Result<GroupAffine<P>, ParseE
     let point =
         GroupAffine::<P>::get_point_from_x(x, greatest).ok_or(ParseError::InvalidXCoordinate)?;
     debug_assert!(point.is_on_curve()); // Always true
-    if !point.is_in_correct_subgroup_assuming_on_curve() {
-        return Err(ParseError::InvalidSubgroup);
-    }
 
     Ok(point)
 }


### PR DESCRIPTION
Makes use of the ark serialisation, and only adapts the bits in the header. This was mostly done to have working version quickly. Should we instead use a more explicit conversion as in parsing?

Also: This removes the subgroup check in the parsing. Doing it like this will reduce performance, since we do the parsing on all powers, while we actually only need to do the check on the last contribution (all others are smaller subsets of this one). Also we have already an explicit way of doing so with `subgroup_check()`.